### PR TITLE
[DRAFT PR] Add Callout

### DIFF
--- a/packages/react-notion-custom/CONTRIBUTING-KR.md
+++ b/packages/react-notion-custom/CONTRIBUTING-KR.md
@@ -652,7 +652,7 @@ fetchNotionPage();
 | To-do                    | ❌ No     | `to_do`                |      |
 | Toggle                   | ✅ Yes    | `toggle`               |      |
 | Quote                    | ❌ No     | `quote`                |      |
-| Callout                  | ❌ No     | `callout`              |      |
+| Callout                  | ✅ Yes    | `callout`              |      |
 | Equation                 | ❌ No     | `equation`             |      |
 | Code                     | ❌ No     | `code`                 |      |
 | Image                    | ❌ No     | `image`                |      |

--- a/packages/react-notion-custom/CONTRIBUTING.md
+++ b/packages/react-notion-custom/CONTRIBUTING.md
@@ -655,7 +655,7 @@ Here's a list of Notion block types currently supported in react-notion-custom. 
 | To-do                    | ❌ No          | `to_do`                |      |
 | Toggle                   | ✅ Yes         | `toggle`               |      |
 | Quote                    | ❌ No          | `quote`                |      |
-| Callout                  | ❌ No          | `callout`              |      |
+| Callout                  | ✅ Yes         | `callout`              |      |
 | Equation                 | ❌ No          | `equation`             |      |
 | Code                     | ❌ No          | `code`                 |      |
 | Image                    | ❌ No          | `image`                |      |

--- a/packages/react-notion-custom/src/lib/components/callout.tsx
+++ b/packages/react-notion-custom/src/lib/components/callout.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import type { CalloutArgs } from "../types";
+import { getColorCss } from "../utils";
+import RichText from "./internal/rich-text";
+import Icon from "./internal/icon";
+
+type CalloutProps = {
+  children?: React.ReactNode;
+} & CalloutArgs;
+
+const Callout: React.FC<CalloutProps> = ({ children, ...props }) => {
+  const { callout } = props;
+
+  return (
+    <div
+      className={`notion-block notion-callout ${getColorCss(callout.color)}`}
+    >
+      <div className="notion-callout-content">
+        <div className="notion-callout-icon" aria-hidden="true">
+          <Icon icon={callout.icon} />
+        </div>
+        <div className="notion-callout-text">
+          <RichText props={callout.rich_text} />
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default Callout;

--- a/packages/react-notion-custom/src/lib/components/index.ts
+++ b/packages/react-notion-custom/src/lib/components/index.ts
@@ -2,8 +2,9 @@ import Headings from "./headings";
 import Paragraph from "./paragraph";
 import Toggle from "./toggle";
 import Equation from "./equation";
+import Callout from "./callout";
 
-export { Headings, Paragraph, Toggle, Equation };
+export { Headings, Paragraph, Toggle, Equation, Callout };
 
 export default {
   heading_1: Headings,
@@ -12,4 +13,5 @@ export default {
   paragraph: Paragraph,
   toggle: Toggle,
   equation: Equation,
+  callout: Callout,
 };

--- a/packages/react-notion-custom/src/lib/components/internal/icon.tsx
+++ b/packages/react-notion-custom/src/lib/components/internal/icon.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+type IconType = "emoji" | "file" | "external";
+
+interface IconProps {
+  icon: {
+    type: IconType;
+    emoji?: string;
+    file?: {
+      url: string;
+    };
+    external?: {
+      url: string;
+    };
+  };
+}
+
+const Icon: React.FC<IconProps> = ({ icon }) => {
+  switch (icon.type) {
+    case "emoji":
+      return <span className="notion-emoji">{icon.emoji}</span>;
+    case "file":
+      return (
+        <img
+          className="notion-icon notion-icon-file"
+          src={icon.file?.url}
+          alt="File Icon"
+        />
+      );
+    case "external":
+      return (
+        <img
+          className="notion-icon notion-icon-external"
+          src={icon.external?.url}
+          alt="External Icon"
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+export default Icon;

--- a/packages/react-notion-custom/src/lib/index.css
+++ b/packages/react-notion-custom/src/lib/index.css
@@ -149,6 +149,38 @@
   border-color: var(--bg-color-2);
 }
 
+.notion-callout {
+  padding: 16px 16px 16px 12px;
+  display: flex;
+  width: 100%;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: transparent;
+}
+
+.notion-callout-content {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.notion-callout-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.notion-callout-text {
+  min-width: 0;
+  width: 100%;
+  margin-top: 2px;
+}
+
 .notion {
   --notion-font: ui-sans-serif, system-ui, apple-system, BlinkMacSystemFont,
     "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif,

--- a/packages/story/src/stories/callout/callout.json
+++ b/packages/story/src/stories/callout/callout.json
@@ -1,0 +1,52 @@
+{
+  "blocks": [
+    {
+      "object": "block",
+      "id": "callout-example-id",
+      "parent": {
+        "type": "page_id",
+        "page_id": "be84ced4-561e-4bd7-a066-36e94cf6f2a1"
+      },
+      "created_time": "2024-09-20T14:55:00.000Z",
+      "last_edited_time": "2024-09-20T14:55:00.000Z",
+      "created_by": {
+        "object": "user",
+        "id": "52c52d67-2221-4853-bae4-9687a30c395a"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "52c52d67-2221-4853-bae4-9687a30c395a"
+      },
+      "has_children": false,
+      "archived": false,
+      "in_trash": false,
+      "type": "callout",
+      "callout": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "This is a callout block",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "This is a callout block",
+            "href": null
+          }
+        ],
+        "icon": {
+          "type": "emoji",
+          "emoji": "💡"
+        },
+        "color": "gray_background"
+      }
+    }
+  ]
+}

--- a/packages/story/src/stories/callout/callout.stories.ts
+++ b/packages/story/src/stories/callout/callout.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Component from "../../lib/Notion";
+import json from "./callout.json";
+
+const blocks = json.blocks as any;
+
+const meta: Meta<typeof Component> = {
+  title: "Blocks/Callout",
+  component: Component,
+};
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+export const Callout: Story = {
+  args: {
+    title: "Callout",
+    blocks: blocks,
+  },
+};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/11835485-309e-4dbb-a9b8-c5102e7da7e8)

## Support for 'Callout' block
- Added a new Callout component to render Notion-style callout blocks.
- Implemented custom styling for the Callout block to match Notion's design.