### PR TITLE
fix : remove duplicate items

### DIFF
--- a/packages/react-notion-custom/CONTRIBUTING-KR.md
+++ b/packages/react-notion-custom/CONTRIBUTING-KR.md
@@ -652,7 +652,6 @@ fetchNotionPage();
 | To-do                    | ❌ No     | `to_do`                |      |
 | Toggle                   | ✅ Yes    | `toggle`               |      |
 | Quote                    | ✅ Yes    | `quote`                |      |
-| Callout                  | ❌ No     | `callout`              |      |
 | Callout                  | ✅ Yes    | `callout`              |      |
 | Equation                 | ❌ No     | `equation`             |      |
 | Code                     | ❌ No     | `code`                 |      |


### PR DESCRIPTION
# Description of Changes

Here is reference: #25

---

## Remove items from duplicate 'Supported Note Block Types'
- I removed the 'Callout' item because it was duplicated.

## Review point

## To reproduce

## Screenshot


## Review Guide

